### PR TITLE
Added #include <iostream> to src/args/Arguments.cc to solve std-strin…

### DIFF
--- a/IdealGasEnergy/src/args/Arguments.cc
+++ b/IdealGasEnergy/src/args/Arguments.cc
@@ -1,6 +1,7 @@
 
 #include <string>
 
+#include <iostream>
 #include "Arguments.h"
 #include <algorithm>
 #include <sstream>


### PR DESCRIPTION
…g error when compiling via make

Compiling can't reference strings when compiling with the server's gsl + gcc modules. This bypasses that error.